### PR TITLE
Fix load tags

### DIFF
--- a/src/svelte/app/index.svelte
+++ b/src/svelte/app/index.svelte
@@ -897,11 +897,7 @@
 	) {
 		formatted = filteredCustom.map((loadedFile) => {
 			const { id, file } = loadedFile;
-			const frontmatter =
-				plugin.app.metadataCache.getFileCache(file)?.frontmatter;
-
 			const isFavorite = favoritesCache.get(file.path) ?? null;
-
 			const content = contentCache.get(file.path) ?? null;
 
 			return formatFileDataForRender({
@@ -909,7 +905,6 @@
 				settings: plugin.settings,
 				fileId: id,
 				file,
-				fileFrontmatter: frontmatter,
 				fileContent: content,
 				fileFavorite: isFavorite,
 			});

--- a/src/svelte/app/services/render-data.ts
+++ b/src/svelte/app/services/render-data.ts
@@ -45,7 +45,6 @@ export const formatFileDataForRender = ({
 	settings,
 	file,
 	fileId,
-	fileFrontmatter,
 	fileContent,
 	fileFavorite,
 }: {
@@ -53,11 +52,12 @@ export const formatFileDataForRender = ({
 	settings: VaultExplorerPluginSettings;
 	file: TFile;
 	fileId: string;
-	fileFrontmatter: FrontMatterCache | undefined;
 	fileContent: string | null;
 	fileFavorite: boolean | null;
 }): FileRenderData => {
 	const { name, basename, extension, path } = file;
+
+	const fileFrontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
 
 	const { loadBodyTags } = settings;
 	const { coverImageSources } = settings.views.grid;
@@ -78,15 +78,14 @@ export const formatFileDataForRender = ({
 		"tags",
 		PropertyType.LIST
 	);
-	if (fileContent && loadBodyTags) {
-		const body = removeFrontmatter(fileContent);
-		const TAG_REGEX = /#\w+(\/\w+)*/g;
-		const bodyTags = body.match(TAG_REGEX);
+
+	if (loadBodyTags) {
+		const bodyTags = app.metadataCache.getFileCache(file)?.tags;
 
 		//Keep the tags array null if there are no tags in the frontmatter or body
-		if (bodyTags !== null && bodyTags.length > 0) {
+		if (bodyTags) {
 			//Remove the hash from the tags
-			const tagsWithoutHash = bodyTags.map((tag) => tag.slice(1));
+			const tagsWithoutHash = bodyTags.map((t) => t.tag.slice(1));
 			tags = Array.from(new Set([...(tags ?? []), ...tagsWithoutHash]));
 		}
 	}

--- a/test-vault/.obsidian/core-plugins-migration.json
+++ b/test-vault/.obsidian/core-plugins-migration.json
@@ -7,7 +7,7 @@
   "canvas": true,
   "outgoing-link": true,
   "tag-pane": true,
-  "properties": false,
+  "properties": true,
   "page-preview": true,
   "daily-notes": false,
   "templates": false,

--- a/test-vault/.obsidian/core-plugins.json
+++ b/test-vault/.obsidian/core-plugins.json
@@ -7,6 +7,7 @@
   "canvas",
   "outgoing-link",
   "tag-pane",
+  "properties",
   "page-preview",
   "note-composer",
   "command-palette",

--- a/test-vault/.obsidian/plugins/vault-explorer/data.json
+++ b/test-vault/.obsidian/plugins/vault-explorer/data.json
@@ -8,7 +8,8 @@
     "creationDate": "creation",
     "modifiedDate": "modification",
     "createdDate": "creation",
-    "image": "image"
+    "image": "image",
+    "coverImageFit": ""
   },
   "filters": {
     "search": {
@@ -60,7 +61,8 @@
           "type": "body",
           "isEnabled": true
         }
-      ]
+      ],
+      "coverImageFit": "cover"
     },
     "list": {
       "isEnabled": true,
@@ -103,6 +105,6 @@
     "feed"
   ],
   "configDir": ".vaultexplorer",
-  "pluginVersion": "1.40.0",
+  "pluginVersion": "1.41.0",
   "logLevel": "trace"
 }

--- a/test-vault/Frontmatter tags with body tags.md
+++ b/test-vault/Frontmatter tags with body tags.md
@@ -1,10 +1,11 @@
 ---
 tags:
-  - tag1
-  - tag2
-  - tag3
+    - tag1
+    - tag2
+    - tag3
 ---
-#tag4 
+
+#tag4
 
 Some text #tag5
 
@@ -13,3 +14,5 @@ Some text #tag5
 This is some text #tag6
 
 #tag/subtag
+
+#1111


### PR DESCRIPTION
Use the Obsidian app.metadataCache for loading body tags. This makes sure that only valid tags are loaded. It also allows the plugin to handle future tag definition changes without breaking.